### PR TITLE
Fixes/denisbelmondo_20230201

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.9.2] The "time goes on, but I'm still lazy" update
+- Fixed: `NULL` was seen as a constant instead of a keyword (like `null` does)
+- My thanks to [@DenisBelmondo](https://github.com/DenisBelmondo) for:
+  - Fixing a spacing-related issue in detecting `state` and `default` ([link](https://github.com/PROPHESSOR/GZDoom-Extension-VSCode/pull/6))
+  - Enhancing classes detection in `default` ([link](https://github.com/PROPHESSOR/GZDoom-Extension-VSCode/pull/7))
+
 ## [1.9.0] The "back to the roots" update
 - Deleted any trace of javascript, again.
 - Added syntax highlighting support for most [Special Lumps](https://zdoom.org/wiki/Special_lumps)
@@ -96,7 +102,7 @@ script "Whatever" ENTER //<-- this one
 - Added experimental ACS support
 - Fixed "folding" error caused by me deleting the zscript language configuration.
 
-## [1.2.0] The "I don't like TypeScript, but at least there's a entry point for you" update
+## [1.2.0] The "I don't like TypeScript, but at least there's an entry point for you" update
 
 - Created entry point for typescript. (So you can extend whatever this extension is.)
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "GZDoom's multiple scripting languages support (with a focus on ZScript) for VSCode (and compatible editors)",
     "publisher": "kaptainmicila",
     "icon": "icons/GZDoom.png",
-    "version": "1.9.1",
+    "version": "1.9.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/KaptainMicila/ZScript-VSCode.git"

--- a/syntaxes/zscript.tmLanguage.json
+++ b/syntaxes/zscript.tmLanguage.json
@@ -115,12 +115,12 @@
                     "match": "\\b0[xX][0-9a-fA-F]+?\\b"
                 },
                 {
-                    "name": "constant.zscript",
-                    "match": "\\b[A-Z_0-9]+?\\b"
-                },
-                {
                     "name": "storage.type.zscript",
                     "match": "\\b(?i:null|void|class|array|bool|const|enum|struct|mixin)\\b|\\b(?<!\\.)[a-z0-9]+?(?=\\s(?!(?:alignof|sizeof|cross|dot|is|true|false))(?:\\w+?))|\\b[a-z0-9]\\w*?(?=\\s+?\\w+?\\()\\b"
+                },
+                {
+                    "name": "constant.zscript",
+                    "match": "\\b[A-Z_0-9]+?\\b"
                 },
                 {
                     "name": "constant.language.boolean.zscript",

--- a/syntaxes/zscript.tmLanguage.json
+++ b/syntaxes/zscript.tmLanguage.json
@@ -200,14 +200,32 @@
                 {
                     "name": "entity.other.default.block.zscript",
                     "begin": "(?i)(?<=^\\s*?\\bdefault\\b)",
-                    "end": "(?<=^)\\s}",
+                    "end": "(?=})",
                     "patterns": [
                         {
                             "include": "#comments"
                         },
                         {
-                            "name": "entity.name.tag.attribute.zscript",
-                            "match": "(?<=\\+|-)\\w+?\\b|(?<=(?<=\\+|-)\\w+?\\.??)\\w+?\\b"
+                            "begin": "(?<=[\\+\\-])",
+                            "end": "(?=$|;)",
+                            "patterns": [
+                                {
+                                    "match": "\\b(\\w+?)\\b\\s*?(?=\\.)",
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.name.class.zscript"
+                                        }
+                                    }
+                                },
+                                {
+                                    "match": "\\b(\\w+?)\\b",
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.name.tag.attribute.zscript"
+                                        }
+                                    }
+                                }
+                            ]
                         },
                         {
                             "include": "#types"
@@ -222,19 +240,27 @@
                             "include": "#keywords"
                         },
                         {
-                            "name": "variable.property.zscript",
-                            "match": "(?<=\\w+?\\.)\\w+?\\b"
+                            "match": "\\b(\\w+?)\\b\\s*?(?=\\.)",
+                            "captures": {
+                                "1": {
+                                    "name": "entity.name.class.zscript"
+                                }
+                            }
                         },
                         {
-                            "name": "variable.name.zscript",
-                            "match": "\\b\\w+?\\b"
+                            "match": "\\b(\\w+?)\\b",
+                            "captures": {
+                                "1": {
+                                    "name": "variable.property.zscript"
+                                }
+                            }
                         }
                     ]
                 },
                 {
                     "name": "entity.other.states.block.zscript",
                     "begin": "(?i)(?<=^\\s*?\\bstates\\b)",
-                    "end": "(?<=^)}",
+                    "end": "(?=})",
                     "patterns": [
                         {
                             "include": "#comments"


### PR DESCRIPTION
- Fixed: `NULL` was seen as a constant instead of a keyword (like `null` does)
- My thanks to [@DenisBelmondo](https://github.com/DenisBelmondo) for:
  - Fixing a spacing-related issue in detecting `state` and `default` ([link](https://github.com/PROPHESSOR/GZDoom-Extension-VSCode/pull/6))
  - Enhancing classes detection in `default` ([link](https://github.com/PROPHESSOR/GZDoom-Extension-VSCode/pull/7))